### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/google.yml
+++ b/.github/workflows/google.yml
@@ -9,6 +9,8 @@
 # 3. Change the values for the GKE_ZONE, GKE_CLUSTER, IMAGE, REGISTRY_HOSTNAME and DEPLOYMENT_NAME environment variables (below).
 
 name: Build and Deploy to GKE
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/sharonstout1981/bug-free-spork/security/code-scanning/1](https://github.com/sharonstout1981/bug-free-spork/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level (root) to define the minimal permissions required. Based on the workflow's operations, it primarily interacts with repository contents (e.g., checking out code) and does not require write access to other resources. Therefore, we will set `contents: read` as the minimal permission. If additional permissions are required in the future, they can be added explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
