### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,7 @@
 name: Build
+permissions:
+  contents: read
+  pull-requests: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/sharonstout1981/bug-free-spork/security/code-scanning/3](https://github.com/sharonstout1981/bug-free-spork/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow involves checking out the repository and performing a SonarQube scan, the minimal required permissions are `contents: read` to access the repository contents and `pull-requests: read` to fetch pull request metadata. These permissions will be added at the workflow level to apply to all jobs, ensuring consistency and security.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
