### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/1stackhawk-analysis.yml
+++ b/.github/workflows/1stackhawk-analysis.yml
@@ -29,6 +29,9 @@
 
 name: "StackHawk"
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ master ]


### PR DESCRIPTION
Potential fix for [https://github.com/sharonstout1981/bug-free-spork/security/code-scanning/4](https://github.com/sharonstout1981/bug-free-spork/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's functionality, it likely only needs `contents: read` to access the repository's code. If additional permissions are required for specific steps, they can be added to the job-specific `permissions` block.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs unless overridden by job-specific permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
